### PR TITLE
Bump to Go 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS builder
+FROM golang:1.26 AS builder
 COPY . /go/src/github.com/skpr/crond
 WORKDIR /go/src/github.com/skpr/crond
 RUN CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o skpr-crond github.com/skpr/crond/cmd/skpr-crond

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/skpr/crond
 
-go 1.25.5
+go 1.26.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
## Overview

Updates to Go 1.26 as a part of security updates.

https://previousnext.atlassian.net/browse/SKPR-1141
